### PR TITLE
feat: 使用手机端的refresh token的方式来操作

### DIFF
--- a/aligo/core/BaseAligo.py
+++ b/aligo/core/BaseAligo.py
@@ -26,6 +26,7 @@ class BaseAligo:
             self,
             name: str = 'aligo',
             refresh_token: str = None,
+            use_refresh_token: bool = False,
             show: Callable[[str], NoReturn] = None,
             level: int = logging.DEBUG,
             loglog: bool = False,
@@ -36,7 +37,7 @@ class BaseAligo:
         :param auth: [Auth] 鉴权对象
         :param use_aria2: [bool] 是否使用 aria2 下载
         """
-        self._auth: Auth = Auth(name=name, refresh_token=refresh_token, show=show, level=level, loglog=loglog)  # type: ignore
+        self._auth: Auth = Auth(name=name, refresh_token=refresh_token, use_refresh_token=use_refresh_token, show=show, level=level, loglog=loglog)  # type: ignore
         # 因为 self._auth.session 没有被重新赋值, 所以可以这么用
         self._session: requests.Session = self._auth.session
         # 在刷新 token 时, self._auth.token 被重新赋值, 而 self._token 却不会被更新

--- a/aligo/core/Config.py
+++ b/aligo/core/Config.py
@@ -17,7 +17,8 @@ V2_OAUTH_AUTHORIZE = '/v2/oauth/authorize'
 V2_OAUTH_TOKEN_LOGIN = '/v2/oauth/token_login'
 
 TOKEN_GET = '/token/get'
-TOKEN_REFRESH = '/token/refresh'
+TOKEN_REFRESH = '/token/refresh'  # TODO: 这个接口可能是旧的接口, 待删除
+V2_ACCOUNT_TOKEN = '/v2/account/token'
 
 V2_USER_GET = '/v2/user/get'
 


### PR DESCRIPTION
使用手机端的refresh token的获取到的 Authorization 方式来操作, 可以避免在现在文件的时候需要带上 referer 的 header, 这样拿到的直链可以直接使用

该方法只有在重新登录之后才会生效

feature issue: #17 