### PR TITLE
增加刷新token时对502错误的处理

### DIFF
--- a/src/aligo/core/Auth.py
+++ b/src/aligo/core/Auth.py
@@ -331,6 +331,13 @@ class Auth:
             else:
                 self.token.x_device_id = self._x_device_id
                 self._save()
+        elif response.status_code == 502:
+            if loop_call:
+                self.log.warning('刷新 token 失败')
+                self.error_log_exit(response)
+            self.log.warning('刷新 token 时出现 502 网关错误，暂停10秒后重试')
+            time.sleep(10)
+            return self._refresh_token(refresh_token=refresh_token, loop_call=True)
         else:
             self.log.warning('刷新 token 失败')
             if loop_call:


### PR DESCRIPTION
使用美西服务器上传文件时偶尔出现刷新token的请求出现502错误，导致程序要求再次扫码登陆，实际中断程序再次运行时无需重新登陆就可以正常刷新。

第一次提交pr不会用，重新提交一次。